### PR TITLE
Error name

### DIFF
--- a/examples/frontend.ipynb
+++ b/examples/frontend.ipynb
@@ -154,20 +154,20 @@
    "metadata": {},
    "outputs": [
     {
-     "ename": "SeaTeaseError",
+     "ename": "SeaBreezeError",
      "evalue": "No unopened device found.",
      "output_type": "error",
      "traceback": [
       "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mSeaTeaseError\u001b[0m                             Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-7-4627b9257058>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;31m# Raises SeaTeaseError, no unopened device\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0mspec2\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0msb\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mspectrometers\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mSpectrometer\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mfrom_first_available\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
-      "\u001b[0;32m~/git/seatease/venv/lib/python3.7/site-packages/seatease-0.1-py3.7.egg/seatease/spectrometers.py\u001b[0m in \u001b[0;36mfrom_first_available\u001b[0;34m(cls)\u001b[0m\n\u001b[1;32m     27\u001b[0m                 \u001b[0;32mreturn\u001b[0m \u001b[0mcls\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mdev\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     28\u001b[0m         \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 29\u001b[0;31m             \u001b[0;32mraise\u001b[0m \u001b[0mcls\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_backend\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mSeaTeaseError\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"No unopened device found.\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     30\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     31\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;31mSeaTeaseError\u001b[0m: No unopened device found."
+      "\u001b[0;31mSeaBreezeError\u001b[0m                             Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-7-4627b9257058>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;31m# Raises SeaBreezeError, no unopened device\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0mspec2\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0msb\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mspectrometers\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mSpectrometer\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mfrom_first_available\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;32m~/git/seatease/venv/lib/python3.7/site-packages/seatease-0.1-py3.7.egg/seatease/spectrometers.py\u001b[0m in \u001b[0;36mfrom_first_available\u001b[0;34m(cls)\u001b[0m\n\u001b[1;32m     27\u001b[0m                 \u001b[0;32mreturn\u001b[0m \u001b[0mcls\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mdev\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     28\u001b[0m         \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 29\u001b[0;31m             \u001b[0;32mraise\u001b[0m \u001b[0mcls\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_backend\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mSeaBreezeError\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"No unopened device found.\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     30\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     31\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mSeaBreezeError\u001b[0m: No unopened device found."
      ]
     }
    ],
    "source": [
-    "# Raises SeaTeaseError, no unopened device\n",
+    "# Raises SeaBreezeError, no unopened device\n",
     "spec2 = sb.spectrometers.Spectrometer.from_first_available()"
    ]
   },

--- a/seatease/cseatease.py
+++ b/seatease/cseatease.py
@@ -1,7 +1,7 @@
 """Module seatease.cseatease
 
 Intended to emulate `seabreeze.cseabreeze`. This provides
-the backend API for the seatease spectrometer classes. 
+the backend API for the seatease spectrometer classes.
 Either, one can use the base front end API (`seatease.spectrometers.Spectrometer`),
 or one can directly use this backend API.
 
@@ -11,19 +11,19 @@ details.
 Example ::
 
     import seatease.cseateast.SeaTeaseAPI as lib
-    
+
     # Lists available devices
     print(lib.list_devices())
-    
+
     # Get the first device
     dev = lib.list_devices()[0]
-    
+
     # use .f to access device features:
     dev.f.spectrometer.get_wavelengths()
-    
+
     # use .features to access device features
     dev.features['spectrometer'][0].get_wavelengths()
-    
+
 """
 
 # TODO
@@ -37,55 +37,55 @@ from time import sleep
 
 class _SeaTeaseAPI:
     """Class for `seatease.cseatease._SeaTeaseAPI`
-    
+
     Intended to emulate the `seabreeze.cseabreeze.SeaBreezeAPI` module.
-    To mimic the hardware behavior (where only a single instance of 
+    To mimic the hardware behavior (where only a single instance of
     each device can exist), this class is used to create a single
     `SeaTeaseAPI` object, which can then be imported by other files.
     This object has a defined number of emulated devices instantiated,
     which when other programs reference them, it will properly raise
-    `SeaTeaseError('Device already open')` errors if the requested
+    `SeaBreezeError('Device already open')` errors if the requested
     device is being used by another thread.
-    
+
     For testing other configurations of spectrometers, override
-    the `SeaTeaseAPI = _SeaTeaseAPI.one_usb2000()` code in this 
+    the `SeaTeaseAPI = _SeaTeaseAPI.one_usb2000()` code in this
     module to instantiate however many devices of whatever type
     you desire.
-    
+
     :param dev_list: A list of `SeaTeaseDevice` instances which are
                      to emulate the spectrometers currently "plugged in"
     """
     def __init__(self, dev_list):
         self.__spectrometers = dev_list
-        
+
     @classmethod
     def one_usb2000(cls):
         return cls([SeaTeaseDevice("1")])
-    
+
     def list_devices(self):
         return self.__spectrometers
-    
+
     def aadd_rs232_device_location(self, device_type, bus_path, baudrate):
         raise NotImplementedError("TODO")
-        
+
     def add_ipv4_device_location(self, device_type, ip_address, port):
         raise NotImplementedError("TODO")
-        
+
     def initialize(self):
         raise NotImplementedError("TODO")
-        
+
     def shutdown(self):
         pass
 
 class SeaTeaseDevice:
     """Class for `seatease.cseatease.SeaTeaseDevice`
-    
+
     Intended to emulate `seabreeze.cseabreeze.SeaBreezeDevice`. See
     that documentation for more details. Currently, there is only
-    support for a USB2000-like device, more devices are to be 
+    support for a USB2000-like device, more devices are to be
     added in future versions.
-    
-    :param serial_number: String representing the serial number of 
+
+    :param serial_number: String representing the serial number of
                             the spectrometer device.
     """
     def __init__(self, serial_number = "1"):
@@ -93,30 +93,30 @@ class SeaTeaseDevice:
         self.__connected = False
         self.__f = f()
         self.__features = {k:[self.__f.__getattribute__(k)] for k in self.__f._attr}
-    
+
     # IDEA:
-    #  - Add a set of classmethods which will instantiate different kinds of 
+    #  - Add a set of classmethods which will instantiate different kinds of
     #     spectrometer types: e.g. SeaTeaseDevice.from_usb2000("1"),
-    #     SeaTeaseDevice.from_usb4000("1"), etc. 
+    #     SeaTeaseDevice.from_usb4000("1"), etc.
     #     To do so, it might be better to als add class methods to f
     #     (f.from_usb2000(), ... ) and then have a single class method
     #     here like SeaTeaseDevice.from_device_type("usb2000")
-    
+
     def __repr__(self):
         return "<SeaTeaseDevice: {}>".format(self.__serial_number)
-    
+
     @property
     def model(self):
         return "USB2000-esk"
     def get_model(self):
         return self.model
-    
+
     @property
     def serial_number(self):
         return self.__serial_number
     def get_serial_number(self):
         return self.serial_number
-    
+
     def close(self):
         self.__connected = False
         return None
@@ -126,22 +126,22 @@ class SeaTeaseDevice:
     @property
     def is_open(self):
         return self.__connected
-    
+
     @property
     def f(self):
         return self.__f
     @property
     def features(self):
         return self.__features
-    
+
 class f:
     """The `seatease.cseatease.SeaTeaseDevice` features class
-    
-    This class emulates the features 'attribute' of the 
+
+    This class emulates the features 'attribute' of the
     `seabreeze.cseabreeze.SeaBreezeDevice` instance, which
     allows '.f' API calls to the backend seabreeze library.
     See `python-seabreeze` backend documentation for details.
-    
+
     Currently, this class only emulates a USB2000-like
     spectrometer, further emulation is projected for the future.
     """
@@ -149,7 +149,7 @@ class f:
     def __init__(self):
         self.spectrometer = SeaTeaseSpectrometerFeature()
         self.eeprom = SeaTeaseEEPROMFeature()
-        
+
 
 class SeaTeaseFeature:
     """Base `seatease.cseatease.SeaTeaseFeature` class
@@ -166,22 +166,22 @@ class SeaTeaseFeature:
 #    def raw_usb_write(self, data, endpoint):
 #        raise NotImplementedError("TODO")
 
-        
+
 class SeaTeaseSpectrometerFeature(SeaTeaseFeature):
     """The `seatease.cseatease.SeaTeaseSpectrometerFeature` class
-    
+
     This class emulates the spectrometer features of a seabreeze
     device. See the `seabreeze.cseabreeze.SeaBreezeSpectrometerFeature`
     documentations for details.
-    
+
     Current emulation only supports a USB2000-like spectrometer,
-    which has a 4096 pixel ccd, ranges from ~300-1000nm and has 
+    which has a 4096 pixel ccd, ranges from ~300-1000nm and has
     a max count of ~4000. Further emulation is projected in future
     versions.
-    
+
     The spectra that this device 'measures' is a single peak at 500nm
     with a FWHM of ~ 40nm (think PL from a quantum dot, or something).
-    The intensities are scaled by the integration time and noise is 
+    The intensities are scaled by the integration time and noise is
     added to roughly match what I have seen on my actual USB2000 device.
     """
     def __init__(self):
@@ -194,7 +194,7 @@ class SeaTeaseSpectrometerFeature(SeaTeaseFeature):
         #   Add functionality to create a 'spectrum' function
         self.__i = np.exp(-(self.__w-500)**2/20)/100
         self.__imax = 4000.0
-    
+
     # Is it overkill to double encapsulate the IT?
     @property
     def _it(self):
@@ -203,14 +203,14 @@ class SeaTeaseSpectrometerFeature(SeaTeaseFeature):
     def _it(self,it):
         # Clip the integration time based on the min/max
         self.__it = int(np.clip(it, self.__itmin, self.__itmax))
-    
+
     def get_electric_dark_pixel_indices(self):
         # No dark pixel functionality
         return []
-    
+
     def get_integration_time_micros_limits(self):
         return self.__itmin, self.__itmax
-        
+
     def get_intensities(self):
         # Have processor sleep to mimic measurement
         sleep(self._it*1e-6)
@@ -219,22 +219,22 @@ class SeaTeaseSpectrometerFeature(SeaTeaseFeature):
         # This noise looks right-ish
         noise = np.random.uniform(0,10,size=4096)
         # Clip results to mimic ccd flooding
-        return np.clip(signal + noise + 100, 0, self.__imax) 
-        
+        return np.clip(signal + noise + 100, 0, self.__imax)
+
     def get_maximum_intensity(self):
         return self.__imax
-        
+
     def get_wavelengths(self):
         return self.__w
-        
+
     def set_integration_time_micros(self, integration_time_micros):
         self._it = integration_time_micros
         return None
-    
+
     def set_trigger_mode(self, mode):
         raise NotImplementedError("TODO")
-        
-    
+
+
 #class SeaTeasePixelBinningFeature(SeaTeaseFeature):
 #    def __init__(self):
 #        pass
@@ -257,7 +257,7 @@ class SeaTeaseSpectrometerFeature(SeaTeaseFeature):
 #        raise NotImplementedError("TODO")
 #    def set_default_binning_factor(self, factor):
 #        raise NotImplementedError("TODO")
-    
+
 #class SeaTeaseThermoElectricFeature(SeaTeaseFeature):
 #    def __init__(self):
 #        pass
@@ -267,7 +267,7 @@ class SeaTeaseSpectrometerFeature(SeaTeaseFeature):
 #        raise NotImplementedError("TODO")
 #    def set_temperature_setpoint_degrees_celsius(self, temperature):
 #        raise NotImplementedError("TODO")
-    
+
 #class SeaTeaseIrradCalFeature(SeaTeaseFeature):
 #    def __init__(self):
 #        pass
@@ -281,10 +281,10 @@ class SeaTeaseSpectrometerFeature(SeaTeaseFeature):
 #        raise NotImplementedError("TODO")
 #    def write_collection_area(self, area):
 #        raise NotImplementedError("TODO")
-    
+
 #class SeaTeaseGPIOFeature(SeaTeaseFeature):
 #    def __init__(self):
-#        pass  
+#        pass
 #    def get_egpio_available_modes(self, pin_number):
 #        raise NotImplementedError("TODO")
 #    def get_egpio_current_mode(self, pin_number):
@@ -310,33 +310,33 @@ class SeaTeaseSpectrometerFeature(SeaTeaseFeature):
 #    def set_gpio_output_enable_vector(self, output_enable_vector, bit_mask):
 #        raise NotImplementedError("TODO")
 #    def set_gpio_value_vector(self, value_vector, bit_mask):
-#        raise NotImplementedError("TODO")  
-    
-    
+#        raise NotImplementedError("TODO")
+
+
 class SeaTeaseEEPROMFeature(SeaTeaseFeature):
     """The `seatease.cseatease.SeaTeaseEEPROMFeature` class
-    
+
     This class emulates the spectrometer features of a seabreeze
     device. See the `seabreeze.cseabreeze.SeaBreezeEEPROMFeature`
     documentations for details.
-    
+
     """
     def __init__(self):
-        pass    
+        pass
     def eeprom_read_slot(self, slot_number, strip_zero_bytes):
         raise NotImplementedError("TODO")
-    
-    
 
-class SeaTeaseError(Exception):
-    """Base `SeaTeaseError`
-    
+
+
+class SeaBreezeError(Exception):
+    """Base `SeaBreezeError`
+
     This is the main exception class which is raised for
     all errors resulting from hardward calls.
     """
     pass
-    
-    
+
+
 SeaTeaseAPI = _SeaTeaseAPI.one_usb2000()
 
 __all__ = ['SeateaseAPI']

--- a/seatease/spectrometers.py
+++ b/seatease/spectrometers.py
@@ -22,10 +22,10 @@ Example Usage::
     spec.integration_time_micros(100*1000) # sets IT to 100ms
     spec.intensities() # Returns fake spectra
     
-    # Returns SeaTeaseError, device already open
+    # Returns SeaBreezeError, device already open
     spec2 = seatease.spectrometers.Spectrometer(dev_list[0])
     
-    # Does NOT return SeaTeaseError
+    # Does NOT return SeaBreezeError
     spec.close()
     spec2 = seatease.spectrometers.Spectrometer(dev_list[0])
 
@@ -75,13 +75,13 @@ class Spectrometer:
         spec.integration_time_micros(100*1000) # sets IT to 100ms
         spec.intensities() # Returns fake spectra
         
-        # Returns SeaTeaseError (only one device is created by default)
+        # Returns SeaBreezeError (only one device is created by default)
         spec2 = seatease.spectrometers.Spectrometer.from_first_available()
         
         # Must be called before device can be re-instantiated
         spec.close()
         
-        # Does NOT return SeaTeaseError
+        # Does NOT return SeaBreezeError
         spec2 = seatease.spectrometers.Spectrometer.from_first_available()
         
     """
@@ -104,7 +104,7 @@ class Spectrometer:
             if not dev.is_open:
                 return cls(dev)
         else:
-            raise cls._backend.SeaTeaseError("No unopened device found.")
+            raise cls._backend.SeaBreezeError("No unopened device found.")
 
 
     @classmethod
@@ -115,11 +115,11 @@ class Spectrometer:
         for dev in list_devices():
             if dev.serial_number == str(serial):
                 if dev.is_open:
-                    raise cls._backend.SeaTeaseError("Device already opened.")
+                    raise cls._backend.SeaBreezeError("Device already opened.")
                 else:
                     return cls(dev)
         else:
-            raise cls._backend.SeaTeaseError("No device attached with serial number '%s'." % serial)
+            raise cls._backend.SeaBreezeError("No device attached with serial number '%s'." % serial)
 
 
     def wavelengths(self):
@@ -129,9 +129,9 @@ class Spectrometer:
     def intensities(self, correct_dark_counts=False, correct_nonlinearity=False):
         # No dark_counts or non_linearity support currently
         if correct_dark_counts:
-            raise self._backend.SeaTeaseError("This device does not support dark count correction.")
+            raise self._backend.SeaBreezeError("This device does not support dark count correction.")
         if correct_nonlinearity:
-            raise self._backend.SeaTeaseError("This device does not support nonlinearity correction.")
+            raise self._backend.SeaBreezeError("This device does not support nonlinearity correction.")
         return self.f.spectrometer.get_intensities()
 
 
@@ -147,7 +147,7 @@ class Spectrometer:
     def integration_time_micros(self, integration_time_micros):
         itl = self.integration_time_micros_limits
         if int(np.clip(integration_time_micros,*itl)) != int(integration_time_micros):
-            raise self._backend.SeaTeaseError(
+            raise self._backend.SeaBreezeError(
                     "Requested integration time ({0} us) outside limits: ({1} us, {2} us)".format(
                         integration_time_micros,
                         *itl

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="seatease",
-    version="0.3.1",
+    version="0.3.2",
     author="Jonathan D B Van Schenck",
     author_email="vanschej@oregonstate.edu",
     description="A software emulator for the `python-seabreeze` package",


### PR DESCRIPTION
Change the name of the base error from `SeaTeaseError` to `SeaBreezeError`, so it can be caught by except statements written for `python-seabreeze`